### PR TITLE
Standardization fixes

### DIFF
--- a/src/background.cpp
+++ b/src/background.cpp
@@ -14,9 +14,9 @@ Background::Background(GMenu2X& gmenu2x)
 
 void Background::paint(Surface& s) {
 	Font& font = *gmenu2x.font;
-	OffscreenSurface& bgmain = *gmenu2x.bgmain;
+	const auto& bgmain = gmenu2x.bgmain;
 
-	bgmain.blit(s, 0, 0);
+	bgmain->blit(s, 0, 0);
 
 #ifdef ENABLE_CLOCK
 	font.write(s, clock.getTime(),

--- a/src/battery.cpp
+++ b/src/battery.cpp
@@ -15,7 +15,7 @@
  */
 unsigned short Battery::getBatteryLevel()
 {
-	unsigned long voltage_min, voltage_max, voltage_now;
+	unsigned long voltage_min = 0, voltage_max = 1, voltage_now = 1;
 	FILE *handle;
 
 	std::string path = powerSupplySysfs + "/status";

--- a/src/browsedialog.cpp
+++ b/src/browsedialog.cpp
@@ -60,7 +60,7 @@ bool BrowseDialog::exec()
 	rowHeight = gmenu2x.font->getLineSpacing() + 1; // gp2x=15+1 / pandora=19+1
 	rowHeight = constrain(rowHeight, 20, 40);
 	numRows = (gmenu2x.height() - topBarHeight - 20) / rowHeight;
-	clipRect = (SDL_Rect) {
+	clipRect = SDL_Rect{
 		0,
 		static_cast<Sint16>(topBarHeight + 1),
 		static_cast<Uint16>(gmenu2x.width() - 9),

--- a/src/browsedialog.cpp
+++ b/src/browsedialog.cpp
@@ -58,7 +58,7 @@ bool BrowseDialog::exec()
 
 	const int topBarHeight = gmenu2x.skinConfInt["topBarHeight"];
 	rowHeight = gmenu2x.font->getLineSpacing() + 1; // gp2x=15+1 / pandora=19+1
-	rowHeight = constrain(rowHeight, 20, 40);
+	rowHeight = std::clamp(rowHeight, 20u, 40u);
 	numRows = (gmenu2x.height() - topBarHeight - 20) / rowHeight;
 	clipRect = SDL_Rect{
 		0,
@@ -71,7 +71,6 @@ bool BrowseDialog::exec()
 	close = false;
 	while (!close) {
 		paint();
-
 		handleInput();
 	}
 

--- a/src/contextmenu.cpp
+++ b/src/contextmenu.cpp
@@ -136,7 +136,7 @@ void ContextMenu::paint(Surface &s)
 	s.box(selbox, gmenu2x.skinConfColors[COLOR_MESSAGE_BOX_SELECTION]);
 
 	// List options.
-	for (uint i = 0; i < options.size(); i++) {
+	for (size_t i = 0; i < options.size(); i++) {
 		font.write(s, options[i]->text, box.x + 12, box.y + 5 + (h + 2) * i,
 				Font::HAlignLeft, Font::VAlignTop);
 	}

--- a/src/contextmenu.h
+++ b/src/contextmenu.h
@@ -12,7 +12,6 @@
 class GMenu2X;
 class Menu;
 
-
 /**
  * A popup dialog containing action on the current section or link.
  */

--- a/src/filelister.cpp
+++ b/src/filelister.cpp
@@ -132,10 +132,9 @@ bool FileLister::browse(const string& path, bool clean)
 			if (ext) ext++; else ext = "";
 
 			for (auto& filterExt : filter) {
-				// Note: strcasecmp can't compare multi-byte UTF-8 characters,
-				//       but the filtered file extensions don't contain any of
-				//       those.
-				if (strcasecmp(ext, filterExt.c_str()) == 0) {
+				// Note: this won't work with UTF8 characters but there shouldn't
+				// be any 
+				if (case_less::to_lower(ext) == case_less::to_lower(filterExt)) {
 					fileSet.insert(string(dptr->d_name));
 					break;
 				}
@@ -164,7 +163,7 @@ bool FileLister::browse(const string& path, bool clean)
 	return true;
 }
 
-string FileLister::operator[](uint x)
+string FileLister::operator[](size_t x)
 {
 	const auto dirCount = directories.size();
 	return x < dirCount ? directories[x] : files[x - dirCount];

--- a/src/filelister.h
+++ b/src/filelister.h
@@ -42,13 +42,13 @@ public:
 	 */
 	bool browse(const std::string& path, bool clean = true);
 
-	unsigned int size() { return files.size() + directories.size(); }
-	unsigned int dirCount() { return directories.size(); }
-	unsigned int fileCount() { return files.size(); }
+	size_t size() const { return files.size() + directories.size(); }
+	size_t dirCount() const { return directories.size(); }
+	size_t fileCount() const { return files.size(); }
 
-	std::string operator[](unsigned int);
-	bool isFile(unsigned int x) { return x >= directories.size(); }
-	bool isDirectory(unsigned int x) { return x < directories.size(); }
+	std::string operator[](size_t);
+	bool isFile(size_t x) const { return x >= directories.size(); }
+	bool isDirectory(size_t x) const { return x < directories.size(); }
 
 	void setFilter(const std::string &filter);
 
@@ -56,8 +56,8 @@ public:
 	void setShowUpdir(bool enabled) { showUpdir = enabled; }
 	void setShowFiles(bool enabled) { showFiles = enabled; }
 
-	const std::vector<std::string> &getDirectories() { return directories; }
-	const std::vector<std::string> &getFiles() { return files; }
+	const std::vector<std::string> &getDirectories() const { return directories; }
+	const std::vector<std::string> &getFiles() const { return files; }
 };
 
 #endif // FILELISTER_H

--- a/src/font.cpp
+++ b/src/font.cpp
@@ -191,12 +191,7 @@ string Font::wordWrapSingleLine(const string &text, size_t start, size_t end, in
 
 int Font::getTextHeight(const string &text) const
 {
-	int nLines = 1;
-	size_t pos = 0;
-	while ((pos = text.find('\n', pos)) != string::npos) {
-		nLines++;
-		pos++;
-	}
+	int nLines = 1 + std::count(text.begin(), text.end(), '\n');
 	return nLines * getLineSpacing();
 }
 

--- a/src/gmenu2x.cpp
+++ b/src/gmenu2x.cpp
@@ -207,9 +207,14 @@ GMenu2X::GMenu2X() : input(*this), sc(this)
 
 	SDL_WM_SetCaption("GMenu2X", nullptr);
 
+#if defined(G2X_BUILD_OPTION_SCREEN_WIDTH) && defined(G2X_BUILD_OPTION_SCREEN_HEIGHT)
+	s = OutputSurface::open(G2X_BUILD_OPTION_SCREEN_WIDTH, G2X_BUILD_OPTION_SCREEN_HEIGHT, 32);
+#else
+	// find largest resolution available
 	for (const auto res : supported_resolutions)
-		if (s = OutputSurface::open(res.first, res.second, confInt["videoBpp"]))
+		if (s = OutputSurface::open(res.first, res.second, 32))
 			break;
+#endif
 
 	if (!s) {
 		ERROR("Failed to create main window\n");
@@ -336,7 +341,7 @@ void GMenu2X::initFont() {
 		if (!size)
 			size = 12;
 		if (path.substr(0,5)=="skin:")
-			path = sc.getSkinFilePath(path.substr(5, path.length()));
+			path = sc.getSkinFilePath(path.substr(5));
 		font.reset(new Font(path, size));
 	} else {
 		font = Font::defaultFont();
@@ -428,7 +433,7 @@ void GMenu2X::readConfig(string conffile) {
 		while (getline(inf, line, '\n')) {
 			string::size_type pos = line.find("=");
 			string name = trim(line.substr(0,pos));
-			string value = trim(line.substr(pos+1,line.length()));
+			string value = trim(line.substr(pos+1));
 
 			if (value.length()>1 && value.at(0)=='"' && value.at(value.length()-1)=='"')
 				confStr[name] = value.substr(1,value.length()-2);
@@ -515,7 +520,7 @@ void GMenu2X::readTmp() {
 		while (getline(inf, line, '\n')) {
 			string::size_type pos = line.find("=");
 			string name = trim(line.substr(0,pos));
-			string value = trim(line.substr(pos+1,line.length()));
+			string value = trim(line.substr(pos+1));
 
 			if (name=="section")
 				menu->setSectionIndex(atoi(value.c_str()));
@@ -792,14 +797,14 @@ bool GMenu2X::readSkinConfig(const string& conffile)
 			DEBUG("skinconf: '%s'\n", line.c_str());
 			string::size_type pos = line.find("=");
 			string name = trim(line.substr(0,pos));
-			string value = trim(line.substr(pos+1,line.length()));
+			string value = trim(line.substr(pos+1));
 
 			if (value.length()>0) {
 				if (value.length()>1 && value.at(0)=='"' && value.at(value.length()-1)=='"')
 					skinConfStr[name] = value.substr(1,value.length()-2);
 				else if (value.at(0) == '#')
 					skinConfColors[stringToColor(name)] =
-						RGBAColor::fromString(value.substr(1, value.length()));
+						RGBAColor::fromString(value.substr(1));
 				else
 					skinConfInt[name] = atoi(value.c_str());
 			}

--- a/src/gmenu2x.cpp
+++ b/src/gmenu2x.cpp
@@ -62,19 +62,11 @@
 #include <SDL.h>
 #include <signal.h>
 
-#include <sys/statvfs.h>
 #include <errno.h>
 
 //for browsing the filesystem
 #include <sys/stat.h>
 #include <sys/types.h>
-#include <dirent.h>
-
-//for soundcard
-#include <sys/ioctl.h>
-#include <linux/soundcard.h>
-
-#include <sys/mman.h>
 
 using namespace std;
 
@@ -145,7 +137,7 @@ int main(int /*argc*/, char * /*argv*/[]) {
 		return 1;
 	}
 
-	gmenu2x_home = (string)home + (string)"/.gmenu2x";
+	gmenu2x_home = (string)home + "/.gmenu2x";
 
 	std::error_code ec;
 	if (!std::filesystem::create_directory(gmenu2x_home, ec) && ec.value()) {
@@ -962,16 +954,16 @@ void GMenu2X::deleteSection()
 }
 
 string GMenu2X::getDiskFree(const char *path) {
-	string df = "";
-	struct statvfs b;
+	
+	std::error_code ec;
+	auto space = std::filesystem::space(path, ec);
 
-	int ret = statvfs(path, &b);
-	if (ret == 0) {
+	string df = "";
+
+	if (!ec) {
 		// Make sure that the multiplication happens in 64 bits.
-		unsigned long freeMiB =
-				((unsigned long long)b.f_bfree * b.f_bsize) / (1024 * 1024);
-		unsigned long totalMiB =
-				((unsigned long long)b.f_blocks * b.f_frsize) / (1024 * 1024);
+		unsigned long freeMiB = space.free / (1024 * 1024);
+		unsigned long totalMiB = space.capacity / (1024 * 1024);
 		stringstream ss;
 		if (totalMiB >= 10000) {
 			ss << (freeMiB / 1024) << "." << ((freeMiB % 1024) * 10) / 1024 << "/"
@@ -980,7 +972,7 @@ string GMenu2X::getDiskFree(const char *path) {
 			ss << freeMiB << "/" << totalMiB << "MiB";
 		}
 		ss >> df;
-	} else WARNING("statvfs failed with error '%s'.\n", strerror(errno));
+	} else WARNING("statvfs failed with error '%s'.\n", ec.message().c_str());
 	return df;
 }
 

--- a/src/gmenu2x.cpp
+++ b/src/gmenu2x.cpp
@@ -1020,7 +1020,7 @@ int GMenu2X::drawButtonRight(Surface& surface, const string &btn,
 	return x - w;
 }
 
-void GMenu2X::drawScrollBar(uint pageSize, uint totalSize, uint pagePos) {
+void GMenu2X::drawScrollBar(uint32_t pageSize, uint32_t totalSize, uint32_t pagePos) {
 	if (totalSize <= pageSize) {
 		// Everything fits on one screen, no scroll bar needed.
 		return;
@@ -1036,8 +1036,8 @@ void GMenu2X::drawScrollBar(uint pageSize, uint totalSize, uint pagePos) {
 	top += 2;
 	height -= 4;
 
-	const uint barSize = max(height * pageSize / totalSize, 4u);
-	const uint barPos = (height - barSize) * pagePos / (totalSize - pageSize);
+	const uint32_t barSize = std::max(height * pageSize / totalSize, 4u);
+	const uint32_t barPos = (height - barSize) * pagePos / (totalSize - pageSize);
 
 	s->box(width() - 6, top + barPos, 3, barSize,
 	       skinConfColors[COLOR_SELECTION_BG]);

--- a/src/gmenu2x.h
+++ b/src/gmenu2x.h
@@ -131,7 +131,7 @@ public:
 	/*
 	 * Variables needed for elements disposition
 	 */
-	uint bottomBarIconY, bottomBarTextY;
+	uint32_t bottomBarIconY, bottomBarTextY;
 	unsigned short cpuX; //!< Offset for displaying cpu clock information
 	unsigned short manualX; //!< Offset for displaying the manual indicator in the taskbar
 
@@ -201,7 +201,7 @@ public:
 
 	int drawButton(Surface& s, const std::string &btn, const std::string &text, int x=5, int y=-10);
 	int drawButtonRight(Surface& s, const std::string &btn, const std::string &text, int x=5, int y=-10);
-	void drawScrollBar(uint pageSize, uint totalSize, uint pagePos);
+	void drawScrollBar(uint32_t pageSize, uint32_t totalSize, uint32_t pagePos);
 
 	void drawTopBar(Surface& s);
 	void drawBottomBar(Surface& s);

--- a/src/imageio.cpp
+++ b/src/imageio.cpp
@@ -11,6 +11,7 @@
 #include <SDL.h>
 #include <png.h>
 #include <cassert>
+#include <memory>
 
 #ifdef HAVE_LIBOPK
 #include <opk.h>
@@ -148,14 +149,15 @@ SDL_Surface *loadPNG(const std::string &path, bool loadAlpha) {
 	//       if it is in the outer scope.
 	{
 		// Compute row pointers.
-		png_bytep rowPointers[height];
+		auto rowPointers = std::make_unique<png_bytep[]>(height);
+
 		for (png_uint_32 y = 0; y < height; y++) {
 			rowPointers[y] =
 				static_cast<png_bytep>(surface->pixels) + y * surface->pitch;
 		}
 
 		// Read the entire image in one go.
-		png_read_image(png, rowPointers);
+		png_read_image(png, rowPointers.get());
 	}
 
 	// Read rest of file, and get additional chunks in the info struct.

--- a/src/inputdialog.cpp
+++ b/src/inputdialog.cpp
@@ -117,7 +117,7 @@ InputDialog::InputDialog(GMenu2X& gmenu2x, InputManager &inputMgr_,
 }
 
 void InputDialog::setKeyboard(int kb) {
-	kb = constrain(kb, 0, keyboard.size() - 1);
+	kb = std::clamp(kb, 0, (int)keyboard.size() - 1);
 	curKeyboard = kb;
 	this->kb = &(keyboard[kb]);
 	kbLength = this->kb->at(0).length();

--- a/src/inputdialog.cpp
+++ b/src/inputdialog.cpp
@@ -244,7 +244,7 @@ void InputDialog::confirm() {
 		close = true;
 	} else {
 		int xc = 0;
-		for (uint x = 0; x < kb->at(selRow).length(); x++) {
+		for (size_t x = 0; x < kb->at(selRow).length(); x++) {
 			bool utf8 = utf8Code(kb->at(selRow)[x]);
 			if (xc == selCol) input += kb->at(selRow).substr(x, utf8 ? 2 : 1);
 			if (utf8) x++;
@@ -286,9 +286,9 @@ void InputDialog::drawVirtualKeyboard() {
 	}
 
 	//keys
-	for (uint l=0; l<kb->size(); l++) {
+	for (size_t l=0; l<kb->size(); l++) {
 		string line = kb->at(l);
-		for (uint x=0, xc=0; x<line.length(); x++) {
+		for (size_t x=0, xc=0; x<line.length(); x++) {
 			string charX;
 			//utf8 characters
 			if (utf8Code(line[x])) {

--- a/src/inputmanager.cpp
+++ b/src/inputmanager.cpp
@@ -36,9 +36,9 @@ bool InputManager::init(Menu *menu)
 
 	repeatRateChanged();
 
-	for (int i = 0; i < BUTTON_TYPE_SIZE; i++) {
-		buttonMap[i].js_mapped = false;
-		buttonMap[i].kb_mapped = false;
+	for (auto& button : buttonMap) {
+		button.js_mapped = false;
+		button.kb_mapped = false;
 	}
 
 	/* If a user-specified input.conf file exists, we load it;

--- a/src/inputmanager.cpp
+++ b/src/inputmanager.cpp
@@ -95,7 +95,7 @@ bool InputManager::readConfFile(const string &conffile) {
 		while (getline(inf, line, '\n')) {
 			string::size_type pos = line.find("=");
 			string name = trim(line.substr(0,pos));
-			line = trim(line.substr(pos+1,line.length()));
+			line = trim(line.substr(pos+1));
 
 			Button button;
 			if (name == "up")            button = UP;
@@ -116,15 +116,15 @@ bool InputManager::readConfFile(const string &conffile) {
 
 			pos = line.find(",");
 			string sourceStr = trim(line.substr(0,pos));
-			line = trim(line.substr(pos+1, line.length()));
+			line = trim(line.substr(pos+1));
 
 			if (sourceStr == "keyboard") {
 				buttonMap[button].kb_mapped = true;
-				buttonMap[button].kb_code = atoi(line.c_str());
+				buttonMap[button].kb_code = std::stoi(line);
 	#ifndef SDL_JOYSTICK_DISABLED
 			} else if (sourceStr == "joystick") {
 				buttonMap[button].js_mapped = true;
-				buttonMap[button].js_code = atoi(line.c_str());
+				buttonMap[button].js_code = std::stoi(line);
 	#endif
 			} else {
 				WARNING("InputManager: Ignoring unknown button source \"%s\"\n",

--- a/src/inputmanager.cpp
+++ b/src/inputmanager.cpp
@@ -306,7 +306,7 @@ void InputManager::startTimer(Joystick *joystick)
 				keyRepeatCallback, joystick);
 }
 
-Uint32 InputManager::joystickRepeatCallback(Uint32 timeout __attribute__((unused)), struct Joystick *joystick)
+Uint32 InputManager::joystickRepeatCallback([[maybe_unused]] Uint32 timeout, struct Joystick *joystick)
 {
 	Uint8 hatState;
 
@@ -322,10 +322,10 @@ Uint32 InputManager::joystickRepeatCallback(Uint32 timeout __attribute__((unused
 		hatState = joystick->hatState;
 
 	SDL_JoyHatEvent e = {
-		.type = SDL_JOYHATMOTION,
-		.which = (Uint8) SDL_JoystickIndex(joystick->joystick),
-		.hat = 0,
-		.value = hatState,
+		SDL_JOYHATMOTION,
+		(Uint8) SDL_JoystickIndex(joystick->joystick),
+		0,
+		hatState,
 	};
 	SDL_PushEvent((SDL_Event *) &e);
 

--- a/src/inputmanager.h
+++ b/src/inputmanager.h
@@ -24,6 +24,7 @@
 #include <SDL.h>
 #include <string>
 #include <vector>
+#include <array>
 
 #define INPUT_KEY_REPEAT_DELAY 250
 
@@ -77,7 +78,7 @@ private:
 	GMenu2X& gmenu2x;
 	Menu *menu;
 
-	ButtonMapEntry buttonMap[BUTTON_TYPE_SIZE];
+	std::array<ButtonMapEntry, BUTTON_TYPE_SIZE> buttonMap;
 #ifndef SDL_JOYSTICK_DISABLED
 	std::vector<Joystick> joysticks;
 

--- a/src/inputmanager.h
+++ b/src/inputmanager.h
@@ -54,7 +54,7 @@ public:
 		// (not included in BUTTON_TYPE_SIZE)
 		REPAINT, QUIT,
 	};
-	#define BUTTON_TYPE_SIZE 10
+	static constexpr size_t BUTTON_TYPE_SIZE = 10;
 
 	InputManager(GMenu2X& gmenu2x);
 	~InputManager();

--- a/src/link.cpp
+++ b/src/link.cpp
@@ -124,7 +124,7 @@ const string &Link::getIcon() {
 
 void Link::loadIcon() {
 	if (icon.compare(0, 5, "skin:") == 0) {
-		setIconPath(gmenu2x.sc.getSkinFilePath(icon.substr(5, string::npos)));
+		setIconPath(gmenu2x.sc.getSkinFilePath(icon.substr(5)));
 	}
 }
 
@@ -133,7 +133,7 @@ void Link::setIcon(const string &icon) {
 
 	if (icon.compare(0, 5, "skin:") == 0)
 		this->iconPath = gmenu2x.sc.getSkinFilePath(
-					icon.substr(5, string::npos));
+					icon.substr(5));
 	else
 		this->iconPath = icon;
 

--- a/src/link.h
+++ b/src/link.h
@@ -82,7 +82,7 @@ private:
 	Action action;
 
 	SDL_Rect rect;
-	uint iconX, padding;
+	uint32_t iconX, padding;
 	int lastTick;
 	std::string title, description;
 };

--- a/src/linkapp.cpp
+++ b/src/linkapp.cpp
@@ -272,7 +272,7 @@ LinkApp::LinkApp(GMenu2X& gmenu2x, string const& linkfile, bool deletable)
 void LinkApp::loadIcon() {
 	if (icon.compare(0, 5, "skin:") == 0) {
 		string linkIcon = gmenu2x.sc.getSkinFilePath(
-				icon.substr(5, string::npos));
+				icon.substr(5));
 		if (!fileExists(linkIcon))
 			searchIcon();
 		else
@@ -294,7 +294,7 @@ const string &LinkApp::searchIcon() {
 	string exectitle = execicon;
 	pos = execicon.rfind("/");
 	if (pos != string::npos)
-		string exectitle = execicon.substr(pos+1,execicon.length());
+		string exectitle = execicon.substr(pos+1);
 
 	if (!gmenu2x.sc.getSkinFilePath("icons/"+exectitle).empty())
 		iconPath = gmenu2x.sc.getSkinFilePath("icons/"+exectitle);

--- a/src/menu.cpp
+++ b/src/menu.cpp
@@ -513,9 +513,11 @@ void Menu::deleteSelectedSection()
 	setSectionIndex(0); //reload sections
 
 	string path = GMenu2X::getHome() + "/sections/" + sectionName;
-	if (rmdir(path.c_str()) && errno != ENOENT) {
+
+	std::error_code ec;
+	if (!std::filesystem::remove(path, ec) && ec) {
 		WARNING("Removal of section dir \"%s\" failed: %s\n",
-				path.c_str(), strerror(errno));
+			path.c_str(), ec.message().c_str());
 	}
 }
 

--- a/src/menu.cpp
+++ b/src/menu.cpp
@@ -180,7 +180,7 @@ bool Menu::runAnimations() {
 }
 
 void Menu::paint(Surface &s) {
-	const uint width = s.width(), height = s.height();
+	const uint32_t width = s.width(), height = s.height();
 	Font &font = *gmenu2x.font;
 	SurfaceCollection &sc = gmenu2x.sc;
 
@@ -206,10 +206,10 @@ void Menu::paint(Surface &s) {
 
 	// Paint section headers.
 	s.box(width / 2  - linkWidth / 2, 0, linkWidth, topBarHeight, selectionBgColor);
-	const uint sectionLinkPadding = (topBarHeight - 32 - font.getLineSpacing()) / 3;
-	const uint numSections = sections.size();
+	const uint32_t sectionLinkPadding = (topBarHeight - 32 - font.getLineSpacing()) / 3;
+	const uint32_t numSections = sections.size();
 	for (int i = leftSection; i <= rightSection; i++) {
-		uint j = (centerSection + numSections + i) % numSections;
+		uint32_t j = (centerSection + numSections + i) % numSections;
 		string sectionIcon = "skin:sections/" + sections[j] + ".png";
 		Surface *icon = sc.exists(sectionIcon)
 				? sc[sectionIcon]
@@ -242,19 +242,19 @@ void Menu::paint(Surface &s) {
 			linkRows, (numLinks + linkColumns - 1) / linkColumns, iFirstDispRow);
 
 	//Links
-	const uint linksPerPage = linkColumns * linkRows;
+	const uint32_t linksPerPage = linkColumns * linkRows;
 	const int linkSpacingX = (width - 10 - linkColumns * linkWidth) / linkColumns;
 	const int linkMarginX = (
 			width - linkWidth * linkColumns - linkSpacingX * (linkColumns - 1)
 			) / 2;
 	const int linkSpacingY = (height - 35 - topBarHeight - linkRows * linkHeight) / linkRows;
-	for (uint i = iFirstDispRow * linkColumns; i < iFirstDispRow * linkColumns + linksPerPage && i < numLinks; i++) {
+	for (uint32_t i = iFirstDispRow * linkColumns; i < iFirstDispRow * linkColumns + linksPerPage && i < numLinks; i++) {
 		const int ir = i - iFirstDispRow * linkColumns;
 		const int x = linkMarginX + (ir % linkColumns) * (linkWidth + linkSpacingX);
 		const int y = ir / linkColumns * (linkHeight + linkSpacingY) + topBarHeight + 2;
 		sectionLinks.at(i)->setPosition(x, y);
 
-		if (i == (uint)iLink) {
+		if (i == (uint32_t)iLink) {
 			sectionLinks.at(i)->paintHover();
 		}
 
@@ -358,7 +358,7 @@ void Menu::setSectionIndex(int i) {
 /*====================================
    LINKS MANAGEMENT
   ====================================*/
-void Menu::addActionLink(uint section, string const& title, Action action,
+void Menu::addActionLink(uint32_t section, string const& title, Action action,
 		string const& description, string const& icon)
 {
 	assert(section < sections.size());
@@ -416,7 +416,7 @@ bool Menu::addLink(string const& path, string const& file)
 		fl.setFilter(".txt");
 		fl.browse(dirPath);
 		bool found = false;
-		for (uint x=0; x<fl.size() && !found; x++) {
+		for (size_t x=0; x<fl.size() && !found; x++) {
 			string lcfilename = fl[x];
 
 			if (lcfilename.find("readme") != string::npos) {
@@ -823,7 +823,7 @@ void Menu::readLinks()
 	iLink = 0;
 	iFirstDispRow = 0;
 
-	for (uint i=0; i<links.size(); i++) {
+	for (size_t i=0; i<links.size(); i++) {
 		links[i].clear();
 
 		int correct = (i>sections.size() ? iSection : i);

--- a/src/menu.cpp
+++ b/src/menu.cpp
@@ -118,6 +118,7 @@ void Menu::readSections(std::string const& parentDir)
 		if (filename[0] != '.')
 			sectionNamed(filename);
 	}
+	//TODO: report anything in case of error?
 }
 
 string Menu::createSectionDir(string const& sectionName)
@@ -364,7 +365,7 @@ void Menu::addActionLink(uint32_t section, string const& title, Action action,
 	link->setDescription(description);
 	if (gmenu2x.sc.exists(icon)
 			|| (icon.substr(0,5)=="skin:"
-				&& !gmenu2x.sc.getSkinFilePath(icon.substr(5,icon.length())).empty())
+				&& !gmenu2x.sc.getSkinFilePath(icon.substr(5)).empty())
 			|| fileExists(icon)) {
 		link->setIcon(icon);
 	}
@@ -385,7 +386,7 @@ bool Menu::addLink(string const& path, string const& file)
 	string title = file;
 	string::size_type pos = title.rfind(".");
 	if (pos!=string::npos && pos>0) {
-		string ext = title.substr(pos, title.length());
+		string ext = title.substr(pos);
 		transform(ext.begin(), ext.end(), ext.begin(), ::tolower);
 		title = title.substr(0, pos);
 	}

--- a/src/menu.cpp
+++ b/src/menu.cpp
@@ -111,18 +111,13 @@ Menu::~Menu()
 
 void Menu::readSections(std::string const& parentDir)
 {
-	DIR *dirp = opendir(parentDir.c_str());
-	if (!dirp) return;
-
-	struct dirent *dptr;
-	while ((dptr = readdir(dirp))) {
-		if (dptr->d_name[0] != '.' && dptr->d_type == DT_DIR) {
-			// Create section if it doesn't exist yet.
-			sectionNamed(dptr->d_name);
-		}
+	std::error_code ec;
+	for (const auto& entry : std::filesystem::directory_iterator(parentDir, ec))
+	{
+		const auto filename = entry.path().filename().string();
+		if (filename[0] != '.')
+			sectionNamed(filename);
 	}
-
-	closedir(dirp);
 }
 
 string Menu::createSectionDir(string const& sectionName)

--- a/src/menu.h
+++ b/src/menu.h
@@ -57,11 +57,11 @@ private:
 	GMenu2X& gmenu2x;
 	IconButton btnContextMenu;
 	int iSection, iLink;
-	uint iFirstDispRow;
+	uint32_t iFirstDispRow;
 	std::vector<std::string> sections;
 	std::vector<std::vector<std::unique_ptr<Link>>> links;
 
-	uint linkColumns, linkRows;
+	uint32_t linkColumns, linkRows;
 
 	Animation sectionAnimation;
 
@@ -121,7 +121,7 @@ public:
 	const std::string &selSection();
 	void setSectionIndex(int i);
 
-	void addActionLink(uint section, std::string const& title,
+	void addActionLink(uint32_t section, std::string const& title,
 			Action action, std::string const& description="",
 			std::string const& icon="");
 	bool addLink(std::string const& path, std::string const& file);

--- a/src/menusettingint.cpp
+++ b/src/menusettingint.cpp
@@ -104,7 +104,7 @@ void MenuSettingInt::dec()
 
 void MenuSettingInt::setValue(int value)
 {
-	*_value = constrain(value,min,max);
+	*_value = std::clamp(value,min,max);
 	stringstream ss;
 	ss << *_value;
 	strvalue = "";

--- a/src/menusettingrgba.cpp
+++ b/src/menusettingrgba.cpp
@@ -111,7 +111,7 @@ bool MenuSettingRGBA::handleButtonPress(InputManager::Button button)
 
 void MenuSettingRGBA::update_value(int value)
 {
-	setSelPart(constrain(getSelPart() + value, 0, 255));
+	setSelPart(std::clamp(getSelPart() + value, 0, 255));
 }
 
 void MenuSettingRGBA::dec()
@@ -126,12 +126,12 @@ void MenuSettingRGBA::inc()
 
 void MenuSettingRGBA::leftComponent()
 {
-	selPart = constrain(selPart-1,0,3);
+	selPart = std::clamp(selPart-1,0,3);
 }
 
 void MenuSettingRGBA::rightComponent()
 {
-	selPart = constrain(selPart+1,0,3);
+	selPart = std::clamp(selPart+1,0,3);
 }
 
 void MenuSettingRGBA::setR(unsigned short r)

--- a/src/messagebox.cpp
+++ b/src/messagebox.cpp
@@ -22,6 +22,9 @@
 #include "gmenu2x.h"
 #include "surface.h"
 
+#include <chrono>
+#include <thread>
+#include <algorithm>
 #include <unistd.h>
 
 using namespace std;
@@ -35,7 +38,7 @@ MessageBox::MessageBox(GMenu2X& gmenu2x, const string &text, const string &icon)
 	, text(text)
 	, icon(icon)
 {
-	for (uint i = 0; i < BUTTON_TYPE_SIZE; i++) {
+	for (uint32_t i = 0; i < InputManager::BUTTON_TYPE_SIZE; i++) {
 		buttons[i] = "";
 		buttonLabels[i] = "";
 		buttonPositions[i].h = gmenu2x.font->getLineSpacing();
@@ -89,7 +92,7 @@ int MessageBox::exec() {
 	gmenu2x.font->write(bg, text, box.x + TEXT_PADDING + (gmenu2x.sc[icon] ? ICON_PADDING + ICON_DIMENSION : 0), box.y + (box.h - textHeight) / 2, Font::HAlignLeft, Font::VAlignTop);
 
 	int btnX = box.x - 6;
-	for (uint i = 0; i < BUTTON_TYPE_SIZE; i++) {
+	for (size_t i = 0; i < InputManager::BUTTON_TYPE_SIZE; i++) {
 		if (!buttons[i].empty()) {
 			buttonPositions[i].y = box.y+box.h+8;
 			buttonPositions[i].w = btnX;
@@ -113,7 +116,7 @@ int MessageBox::exec() {
 			result = button;
 		}
 
-		usleep(LOOP_DELAY);
+		std::this_thread::sleep_for(std::chrono::microseconds(LOOP_DELAY));
 	}
 
 	return result;

--- a/src/messagebox.h
+++ b/src/messagebox.h
@@ -38,9 +38,9 @@ public:
 private:
 	GMenu2X& gmenu2x;
 	std::string text, icon;
-	std::string buttons[BUTTON_TYPE_SIZE];
-	std::string buttonLabels[BUTTON_TYPE_SIZE];
-	SDL_Rect buttonPositions[BUTTON_TYPE_SIZE];
+	std::string buttons[InputManager::BUTTON_TYPE_SIZE];
+	std::string buttonLabels[InputManager::BUTTON_TYPE_SIZE];
+	SDL_Rect buttonPositions[InputManager::BUTTON_TYPE_SIZE];
 };
 
 #endif // MESSAGEBOX_H

--- a/src/selector.cpp
+++ b/src/selector.cpp
@@ -94,7 +94,7 @@ int Selector::exec(int startSelection) {
 	bg.convertToDisplayFormat();
 
 	unsigned int firstElement = 0;
-	unsigned int selected = constrain(startSelection, 0, fl.size() - 1);
+	unsigned int selected = std::clamp(startSelection, 0, (int)fl.size() - 1);
 
 	bool close = false, result = true;
 	while (!close) {

--- a/src/settingsdialog.cpp
+++ b/src/settingsdialog.cpp
@@ -46,15 +46,15 @@ bool SettingsDialog::exec() {
 	bg.convertToDisplayFormat();
 
 	bool close = false;
-	uint i, sel = 0, firstElement = 0;
+	uint32_t i, sel = 0, firstElement = 0;
 
 	const int topBarHeight = gmenu2x.skinConfInt["topBarHeight"];
-	uint rowHeight = gmenu2x.font->getLineSpacing() + 1; // gp2x=15+1 / pandora=19+1
-	uint numRows = (gmenu2x.height() - topBarHeight - 20) / rowHeight;
+	uint32_t rowHeight = gmenu2x.font->getLineSpacing() + 1; // gp2x=15+1 / pandora=19+1
+	uint32_t numRows = (gmenu2x.height() - topBarHeight - 20) / rowHeight;
 
-	uint maxNameWidth = 0;
+	uint32_t maxNameWidth = 0;
 	for (auto it = settings.begin(); it != settings.end(); it++) {
-		maxNameWidth = max(maxNameWidth, (uint) gmenu2x.font->getTextWidth((*it)->getName()));
+		maxNameWidth = std::max(maxNameWidth, (uint32_t) gmenu2x.font->getTextWidth((*it)->getName()));
 	}
 
 	while (!close) {
@@ -73,7 +73,7 @@ bool SettingsDialog::exec() {
 		if (sel<firstElement) firstElement=sel;
 
 		//selection
-		uint iY = topBarHeight + 2 + (sel - firstElement) * rowHeight;
+		uint32_t iY = topBarHeight + 2 + (sel - firstElement) * rowHeight;
 
 		//selected option
 		settings[sel]->drawSelected(maxNameWidth + 15, iY, rowHeight);

--- a/src/surface.cpp
+++ b/src/surface.cpp
@@ -23,6 +23,7 @@
 #include "debug.h"
 #include "imageio.h"
 #include "utilities.h"
+#include "buildopts.h"
 
 #include <algorithm>
 #include <cassert>
@@ -36,13 +37,13 @@ using namespace std;
 
 RGBAColor RGBAColor::fromString(const string &strColor) {
 	return {
-		uint8_t(constrain(strtol(strColor.substr(0, 2).c_str(), nullptr, 16),
+		uint8_t(std::clamp(std::stoi(strColor.substr(0, 2), nullptr, 16),
 		                  0, 255)),
-		uint8_t(constrain(strtol(strColor.substr(2, 2).c_str(), nullptr, 16),
+		uint8_t(std::clamp(std::stoi(strColor.substr(2, 2).c_str(), nullptr, 16),
 		                  0, 255)),
-		uint8_t(constrain(strtol(strColor.substr(4, 2).c_str(), nullptr, 16),
+		uint8_t(std::clamp(std::stoi(strColor.substr(4, 2).c_str(), nullptr, 16),
 		                  0, 255)),
-		uint8_t(constrain(strtol(strColor.substr(6, 2).c_str(), nullptr, 16),
+		uint8_t(std::clamp(std::stoi(strColor.substr(6, 2).c_str(), nullptr, 16),
 		                  0, 255)),
 	};
 }
@@ -339,8 +340,14 @@ unique_ptr<OutputSurface> OutputSurface::open(
 		int width, int height, int bitsPerPixel)
 {
 	SDL_ShowCursor(SDL_DISABLE);
+	Uint32 flags = SDL_HWSURFACE | SDL_DOUBLEBUF;
+
+#if !defined(G2X_BUILD_OPTION_WINDOWED_MODE)
+	flags |= SDL_FULLSCREEN;
+#endif
+
 	SDL_Surface *raw = SDL_SetVideoMode(
-		width, height, bitsPerPixel, SDL_HWSURFACE | SDL_DOUBLEBUF | SDL_FULLSCREEN);
+		width, height, bitsPerPixel, flags);
 	return unique_ptr<OutputSurface>(raw ? new OutputSurface(raw) : nullptr);
 }
 

--- a/src/surface.h
+++ b/src/surface.h
@@ -64,17 +64,17 @@ public:
 
 	void box(SDL_Rect re, RGBAColor c);
 	void box(Sint16 x, Sint16 y, Uint16 w, Uint16 h, RGBAColor c) {
-		box((SDL_Rect){ x, y, w, h }, c);
+		box(SDL_Rect{ x, y, w, h }, c);
 	}
 	void box(Sint16 x, Sint16 y, Uint16 w, Uint16 h, Uint8 r, Uint8 g, Uint8 b, Uint8 a) {
-		box((SDL_Rect){ x, y, w, h }, RGBAColor(r, g, b, a));
+		box(SDL_Rect{ x, y, w, h }, RGBAColor(r, g, b, a));
 	}
 	void rectangle(SDL_Rect re, RGBAColor c);
 	void rectangle(Sint16 x, Sint16 y, Uint16 w, Uint16 h, RGBAColor c) {
-		rectangle((SDL_Rect){ x, y, w, h }, c);
+		rectangle(SDL_Rect{ x, y, w, h }, c);
 	}
 	void rectangle(Sint16 x, Sint16 y, Uint16 w, Uint16 h, Uint8 r, Uint8 g, Uint8 b, Uint8 a) {
-		rectangle((SDL_Rect){ x, y, w, h }, RGBAColor(r, g, b, a));
+		rectangle(SDL_Rect{ x, y, w, h }, RGBAColor(r, g, b, a));
 	}
 
 protected:

--- a/src/surfacecollection.cpp
+++ b/src/surfacecollection.cpp
@@ -99,7 +99,7 @@ OffscreenSurface *SurfaceCollection::add(const string &path) {
 	string filePath = path;
 
 	if (filePath.substr(0,5)=="skin:") {
-		filePath = getSkinFilePath(filePath.substr(5,filePath.length()));
+		filePath = getSkinFilePath(filePath.substr(5));
 		if (filePath.empty())
 			return NULL;
 	} else if ((filePath.find('#') == filePath.npos) && (!fileExists(filePath))) {

--- a/src/textmanualdialog.cpp
+++ b/src/textmanualdialog.cpp
@@ -33,7 +33,7 @@ TextManualDialog::TextManualDialog(GMenu2X& gmenu2x, const string &title, const 
 	: TextDialog(gmenu2x, title, "", icon, text)
 {
 	//split the text in multiple pages
-	for (uint i=0; i<this->text.size(); i++) {
+	for (size_t i=0; i<this->text.size(); i++) {
 		string line = trim(this->text.at(i));
 		if (line[0]=='[' && line[line.length()-1]==']') {
 			ManualPage mp;

--- a/src/utilities.cpp
+++ b/src/utilities.cpp
@@ -34,29 +34,40 @@
 #include <fstream>
 #include <iostream>
 #include <sstream>
-#include <strings.h>
+#include <cctype>
+#include <filesystem>
 #include <unistd.h>
 
 using namespace std;
 
 bool case_less::operator()(const string &left, const string &right) const {
-	return strcasecmp(left.c_str(), right.c_str()) < 0;
+	return std::equal(left.begin(), left.end(), right.begin(), right.end(), 
+		[](string::value_type c1, string::value_type c2) { return std::tolower(c1) < std::tolower(c2);
+	});
+}
+
+std::string case_less::to_lower(std::string data)
+{
+	std::transform(data.begin(), data.end(), data.begin(), 
+		[](std::string::value_type c) { return std::tolower(c); }
+	);
+	return data;
 }
 
 string trim(const string& s) {
-  auto b = s.find_first_not_of(" \t\r");
-  auto e = s.find_last_not_of(" \t\r");
-  return b == string::npos ? "" : string(s, b, e + 1 - b);
+	auto b = s.find_first_not_of(" \t\r");
+	auto e = s.find_last_not_of(" \t\r");
+	return b == string::npos ? "" : string(s, b, e + 1 - b);
 }
 
 string ltrim(const string& s) {
-  auto b = s.find_first_not_of(" \t\r");
-  return b == string::npos ? "" : string(s, b);
+	auto b = s.find_first_not_of(" \t\r");
+	return b == string::npos ? "" : string(s, b);
 }
 
 string rtrim(const string& s) {
-  auto e = s.find_last_not_of(" \t\r");
-  return e == string::npos ? "" : string(s, 0, e + 1);
+	auto e = s.find_last_not_of(" \t\r");
+	return e == string::npos ? "" : string(s, 0, e + 1);
 }
 
 // See this article for a performance comparison of different approaches:
@@ -219,7 +230,7 @@ string strreplace (string orig, const string &search, const string &replace) {
 
 string cmdclean (string cmdline) {
 	string spchars = "\\`$();|{}&'\"*?<>[]!^~-#\n\r ";
-	for (uint i=0; i<spchars.length(); i++) {
+	for (size_t i=0; i<spchars.length(); i++) {
 		string curchar = spchars.substr(i,1);
 		cmdline = strreplace(cmdline, curchar, "\\"+curchar);
 	}
@@ -237,9 +248,7 @@ void request_repaint()
 	if (!PowerSaver::getInstance()->getScreenState())
 		return;
 
-	SDL_UserEvent e = {
-		.type = SDL_USEREVENT,
-	};
+	SDL_UserEvent e = { SDL_USEREVENT };
 
 	/* Inject an user event, that will be handled as a "repaint"
 	 * event by the InputManager */

--- a/src/utilities.cpp
+++ b/src/utilities.cpp
@@ -186,17 +186,13 @@ string uniquePath(string const& dir, string const& name)
 	return path;
 }
 
-int constrain(int x, int imin, int imax) {
-	return min(imax, max(imin, x));
-}
-
 //Configuration parsing utilities
 int evalIntConf (ConfIntHash& hash, const std::string &key, int def, int imin, int imax) {
 	auto it = hash.find(key);
 	if (it == hash.end()) {
 		return hash[key] = def;
 	} else {
-		return it->second = constrain(it->second, imin, imax);
+		return it->second = std::clamp(it->second, imin, imax);
 	}
 }
 
@@ -239,7 +235,7 @@ string cmdclean (string cmdline) {
 
 int intTransition(int from, int to, long tickStart, long duration, long tickNow) {
 	if (tickNow<0) tickNow = SDL_GetTicks();
-	return constrain(((tickNow-tickStart) * (to-from)) / duration, from, to);
+	return std::clamp((int)(((tickNow-tickStart) * (to-from)) / duration), from, to);
 	//                    elapsed                 increments
 }
 

--- a/src/utilities.h
+++ b/src/utilities.h
@@ -27,8 +27,8 @@
 
 #include "inputmanager.h"
 
-typedef std::unordered_map<std::string, std::string, std::hash<std::string>> ConfStrHash;
-typedef std::unordered_map<std::string, int, std::hash<std::string>> ConfIntHash;
+using ConfStrHash = std::unordered_map<std::string, std::string>;
+using ConfIntHash = std::unordered_map<std::string, int>;
 
 class case_less {
 public:

--- a/src/utilities.h
+++ b/src/utilities.h
@@ -33,6 +33,7 @@ typedef std::unordered_map<std::string, int, std::hash<std::string>> ConfIntHash
 class case_less {
 public:
 	bool operator()(const std::string &left, const std::string &right) const;
+	static std::string to_lower(std::string input);
 };
 
 inline bool isUTF8Starter(char c) {

--- a/src/wallpaperdialog.cpp
+++ b/src/wallpaperdialog.cpp
@@ -61,7 +61,7 @@ bool WallpaperDialog::exec()
 
 	DEBUG("Wallpapers: %zd\n", wallpapers.size());
 
-	uint i, selected = 0, firstElement = 0, iY;
+	uint32_t i, selected = 0, firstElement = 0, iY;
 
 	ButtonBox buttonbox;
 	buttonbox.add(unique_ptr<IconButton>(new IconButton(gmenu2x, "skin:imgs/buttons/accept.png", gmenu2x.tr["Select"])));
@@ -147,7 +147,7 @@ bool WallpaperDialog::exec()
         }
 	}
 
-	for (uint i=0; i<wallpapers.size(); i++) {
+	for (size_t i=0; i<wallpapers.size(); i++) {
 	  gmenu2x.sc.del("skin:wallpapers/" + wallpapers[i]);
 	}
 


### PR DESCRIPTION
This pull request is aimed to refactor and beautify the code:

- removed non-standard constructs allowed by GCC compiler but not by C++ standard (eg. designated initializers, `uint`)
- increased utilization of some C++11/C++17 STL functions like `std::clamp`, `std::stoi` and such
- `std::chrono` instead of `<sys/time.h>`
- continued replacing POSIX like file system access functions with `std::filesystem`
- added build options to force windowed mode and specific resolution for debugging
